### PR TITLE
fix: return key instead of ket

### DIFF
--- a/src/AnimatedTabBar.tsx
+++ b/src/AnimatedTabBar.tsx
@@ -53,7 +53,7 @@ export const AnimatedTabBar = (props: AnimatedTabBarProps) => {
         index: props.navigation.state.index,
         // @ts-ignore
         routes: props.navigation.state.routes,
-        ket: '',
+        key: '',
       };
     }
   }, [props, isReactNavigation5]);


### PR DESCRIPTION
Support for react navigation-v4 was returning `ket` instead of `key`