### PR TITLE
Support to tweak the size of the tab bar

### DIFF
--- a/src/AnimatedTabBar.tsx
+++ b/src/AnimatedTabBar.tsx
@@ -25,6 +25,11 @@ interface AnimatedTabBarProps extends BottomTabBarProps, AnimationConfigProps {
    * Root container style.
    */
   style?: StyleProp<ViewStyle>;
+  
+  /**
+   * Bar item style
+   */
+  itemStyle?: StyleProp<ViewStyle>;
 }
 
 export const AnimatedTabBar = (props: AnimatedTabBarProps) => {
@@ -35,6 +40,7 @@ export const AnimatedTabBar = (props: AnimatedTabBarProps) => {
     duration,
     easing,
     style: containerStyleOverride,
+    itemStyle: itemStyleOverride,
   } = props;
 
   // variables
@@ -144,6 +150,7 @@ export const AnimatedTabBar = (props: AnimatedTabBarProps) => {
             label={label}
             duration={duration}
             easing={easing}
+            containerStyle={itemStyleOverride}
             {...configs}
           />
         );

--- a/src/AnimatedTabBar.tsx
+++ b/src/AnimatedTabBar.tsx
@@ -64,10 +64,10 @@ export const AnimatedTabBar = (props: AnimatedTabBarProps) => {
   const containerStyle = useMemo(
     () => [
       styles.container,
-      containerStyleOverride,
       {
         paddingBottom: safeArea.bottom,
       },
+      containerStyleOverride,
     ],
     [safeArea, containerStyleOverride]
   );

--- a/src/item/AnimatedTabBarItem.tsx
+++ b/src/item/AnimatedTabBarItem.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, memo } from 'react';
-import { View } from 'react-native';
+import { View, StyleProp, ViewStyle } from 'react-native';
 import Animated, { Easing } from 'react-native-reanimated';
 import {
   TouchableWithoutFeedback,
@@ -30,6 +30,7 @@ interface AnimatedTabBarItemProps extends AnimationConfigProps, TabConfigsType {
   selectedIndex: Animated.Value<number>;
   label: string;
   allowFontScaling?: boolean;
+  containerStyle?: StyleProp<ViewStyle>
 }
 
 const AnimatedTabBarItemComponent = (props: AnimatedTabBarItemProps) => {
@@ -44,6 +45,7 @@ const AnimatedTabBarItemComponent = (props: AnimatedTabBarItemProps) => {
     labelStyle: labelStyleOverride,
     duration = 500,
     easing = Easing.out(Easing.exp),
+    containerStyle: containerStyleOverride,
   } = props;
 
   // variables
@@ -75,6 +77,7 @@ const AnimatedTabBarItemComponent = (props: AnimatedTabBarItemProps) => {
   //#region styles
   const containerStyle = [
     styles.container,
+    containerStyleOverride,
     {
       width: interpolate(animatedFocus, {
         inputRange: [0, 1],


### PR DESCRIPTION
Thanks for this library, it's quite amazing! The default size of the tab bar is too large for my current user interface so I needed a way to tweak its size.

The best way would be to adjust the `paddingBottom` and the `padding` values on both the `AnimatedTabBar` and `AnimatedTabBarItem` respectively, but this was not supported originally.

Any custom `paddingBottom` on the tab bar was being over-ridden by the default value (from the `safeArea`) which didn't allow for customisation.

Likewise, there was no prop to customise the style of the item container, so I decided to add them in. They're only minor changes and really should be non breaking.