### PR TITLE
feat: Export individual tabbar components and associated props

### DIFF
--- a/src/bubble/index.ts
+++ b/src/bubble/index.ts
@@ -1,2 +1,3 @@
 export { default } from './BubbleTabBar';
+export { default as BubbleTabBarItem, BubbleTabBarItemProps } from './item';
 export { BubbleTabConfig, BubbleTabIconProps } from './types';

--- a/src/bubble/item/BubbleTabBarItem.tsx
+++ b/src/bubble/item/BubbleTabBarItem.tsx
@@ -35,9 +35,9 @@ const { add, interpolate, useCode, set, cond, eq } = Animated;
 const gestureHandler = (state: Animated.Value<State>) =>
   onGestureEvent({ state });
 
-const BubbleTabBarItemComponent = (
-  props: TabBarItemProps & BubbleTabConfig
-) => {
+export type BubbleTabBarItemProps = TabBarItemProps & BubbleTabConfig;
+
+const BubbleTabBarItemComponent = (props: BubbleTabBarItemProps) => {
   // props
   const {
     index,

--- a/src/bubble/item/index.ts
+++ b/src/bubble/item/index.ts
@@ -1,1 +1,1 @@
-export { default } from './BubbleTabBarItem';
+export { default, BubbleTabBarItemProps } from './BubbleTabBarItem';

--- a/src/flashy/index.ts
+++ b/src/flashy/index.ts
@@ -1,2 +1,3 @@
 export { default } from './FlashyTabBar';
+export { default as FlashyTabBarItem, FlashyTabBarItemProps } from './item';
 export { FlashyTabConfig, FlashyTabIconProps } from './types';

--- a/src/flashy/item/FlashyTabBarItem.tsx
+++ b/src/flashy/item/FlashyTabBarItem.tsx
@@ -57,9 +57,10 @@ const {
 const gestureHandler = (state: Animated.Value<State>) =>
   onGestureEvent({ state });
 
-const FlashyTabBarItemComponent = (
-  props: Omit<TabBarItemProps, 'itemOuterSpace'> & FlashyTabConfig
-) => {
+export type FlashyTabBarItemProps = Omit<TabBarItemProps, 'itemOuterSpace'> &
+  FlashyTabConfig;
+
+const FlashyTabBarItemComponent = (props: FlashyTabBarItemProps) => {
   // props
   const {
     index,

--- a/src/flashy/item/index.ts
+++ b/src/flashy/item/index.ts
@@ -1,1 +1,1 @@
-export { default } from './FlashyTabBarItem';
+export { default, FlashyTabBarItemProps } from './FlashyTabBarItem';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,16 @@
 export { AnimatedTabBar as default } from './AnimatedTabBar';
-import { BubbleTabConfig, BubbleTabIconProps } from './bubble';
-export { FlashyTabConfig, FlashyTabIconProps } from './flashy';
+import {
+  BubbleTabConfig,
+  BubbleTabIconProps,
+  BubbleTabBarItem,
+  BubbleTabBarItemProps,
+} from './bubble';
+export {
+  FlashyTabConfig,
+  FlashyTabIconProps,
+  FlashyTabBarItem,
+  FlashyTabBarItemProps,
+} from './flashy';
 import { TabsConfig } from './types';
 
 /**
@@ -9,4 +19,10 @@ import { TabsConfig } from './types';
  */
 export type TabsConfigsType = TabsConfig<BubbleTabConfig>;
 
-export { BubbleTabConfig, BubbleTabIconProps, TabsConfig };
+export {
+  BubbleTabConfig,
+  BubbleTabIconProps,
+  BubbleTabBarItem,
+  BubbleTabBarItemProps,
+  TabsConfig,
+};


### PR DESCRIPTION
This is particularly helpful for constructing a custom tabbar that is partially composed of tab buttons (for example, if you want a FAB button in the middle).