### PR TITLE
fixing issue in react-native-redash

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "lodash.isequal": "^4.5.0",
-    "react-native-redash": "15.7.3"
+    "react-native-redash": "16.0.11"
   },
   "devDependencies": {
     "@commitlint/cli": "^9.1.1",


### PR DESCRIPTION
fixing issue in `react-native-redash`
`react-native-redash` has issue with `react-native-reanimated` lib as in [Here](https://github.com/wcandillon/react-native-redash/issues/429)

and update the `redash` lib fix this issue and #110
