### PR TITLE
feat: minor changes to support react navigation 6 for tab bar visibility option

### DIFF
--- a/src/AnimatedTabBar.tsx
+++ b/src/AnimatedTabBar.tsx
@@ -82,7 +82,16 @@ export function AnimatedTabBar<T extends PresetEnum>(
     }
     const route = routes[navigationIndex];
     const { options } = descriptors[route.key];
-    return options.tabBarVisible ?? true;
+
+    // React Navigation 5
+    if (typeof options.tabBarVisible === 'boolean') {
+      return options.tabBarVisible;
+    }
+
+    // React Navigation 6
+    const { tabBarStyle } = options;
+
+    return (tabBarStyle?.display || 'flex') === 'flex';
   }, [isReactNavigation5, routes, descriptors, navigationIndex]);
 
   const shouldShowTabBarAnimated = useTabBarVisibility(shouldShowTabBar);


### PR DESCRIPTION
As mentionned in #121, The tabBarVisible option is no longer present we need to check the existence and value of tabBarStyle.

Fix #121 